### PR TITLE
Efficiency improvement, updated readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,12 +39,6 @@ LABEL description="This image provides a Docker container for the Monocle Gatewa
 LABEL version=$BUILD_VERSION
 
 # ---------------------------------------
-# Create Monocle Gateway configuration 
-# directory
-# ---------------------------------------
-RUN mkdir -p /etc/monocle
-
-# ---------------------------------------
 # Install Monocle Gateway dependencies
 # ---------------------------------------
 RUN apt update && apt install -y \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This fork of Monocle Gateway is the [32-bit (ARMv8)](https://monoclecam.com/monocle-gateway/install/linux-raspi) version which builds into a Docker image running [Debian:Buster-slim](https://hub.docker.com/layers/debian/library/debian/buster-slim/images/sha256-aee124e7c4ace4488a679d30ae9a02eb68e674f983e6066b547dd02b07bc572b?context=explore) as its base file system. It has only been tested on a Raspberry Pi 4 running the Raspbian Lite OS.
+This fork of Monocle Gateway is the [32-bit (ARMv7 and ARMv8)](https://monoclecam.com/monocle-gateway/install/linux-raspi) version which builds into a Docker image running [Debian:Buster-slim](https://hub.docker.com/layers/debian/library/debian/buster-slim/images/sha256-aee124e7c4ace4488a679d30ae9a02eb68e674f983e6066b547dd02b07bc572b?context=explore) as its base file system. It has been tested on a Raspberry Pi 4 running the Raspbian and Raspbian Lite OS.
 
 To build the image:
 - Save the Dockerfile to your system.


### PR DESCRIPTION
Removed the RUN layer creating the empty directory as the package will do that on its own. Updated readme to confirm compatibility with armv7 and Raspbian full OS (though the OS seems irrelevant for a docker container).

Thanks for making this version. I wasn't sure which base image to use instead of alpine, or what other changes needed to be made and this helped me learn.